### PR TITLE
fix: correct CV PDF links in team page

### DIFF
--- a/src/pages/team/index.astro
+++ b/src/pages/team/index.astro
@@ -33,7 +33,8 @@ import '../../style/team.css';
                             </span>
                             GitHub
                         </a>
-                        <a href="../../public/CV/CV_SOTELO.pdf" target="_blank">
+                        <!-- CV link: Files in public/ are served from root, so /CV/filename.pdf is the correct path -->
+                        <a href="/CV/CV_SOTELO.pdf" target="_blank">
                             <span class="icon">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 24 24"><path d="M6 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8.828A2 2 0 0 0 19.414 7.414l-4.828-4.828A2 2 0 0 0 13.172 2H6zm6 1.414L18.586 10H14a2 2 0 0 1-2-2V3.414z"/></svg>
                             </span>
@@ -64,7 +65,8 @@ import '../../style/team.css';
                             </span>
                             GitHub
                         </a>
-                        <a href="../../../public/CV/CV_PAULI.pdf" target="_blank">
+                        <!-- CV link: Files in public/ are served from root, so /CV/filename.pdf is the correct path -->
+                        <a href="/CV/CV_PAULI.pdf" target="_blank">
                             <span class="icon">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 24 24"><path d="M6 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8.828A2 2 0 0 0 19.414 7.414l-4.828-4.828A2 2 0 0 0 13.172 2H6zm6 1.414L18.586 10H14a2 2 0 0 1-2-2V3.414z"/></svg>
                             </span>
@@ -94,7 +96,8 @@ import '../../style/team.css';
                             </span>
                             GitHub
                         </a>
-                        <a href="../../../public/CV/CV_JOACO.pdf" target="_blank">
+                        <!-- CV link: Files in public/ are served from root, so /CV/filename.pdf is the correct path -->
+                        <a href="/CV/CV_JOACO.pdf" target="_blank">
                             <span class="icon">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 24 24"><path d="M6 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8.828A2 2 0 0 0 19.414 7.414l-4.828-4.828A2 2 0 0 0 13.172 2H6zm6 1.414L18.586 10H14a2 2 0 0 1-2-2V3.414z"/></svg>
                             </span>
@@ -124,7 +127,8 @@ import '../../style/team.css';
                             </span>
                             GitHub
                         </a>
-                        <a href="../../../public/CV/CV_SOFI.pdf" target="_blank">
+                        <!-- CV link: Files in public/ are served from root, so /CV/filename.pdf is the correct path -->
+                        <a href="/CV/CV_SOFI.pdf" target="_blank">
                             <span class="icon">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 24 24"><path d="M6 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8.828A2 2 0 0 0 19.414 7.414l-4.828-4.828A2 2 0 0 0 13.172 2H6zm6 1.414L18.586 10H14a2 2 0 0 1-2-2V3.414z"/></svg>
                             </span>
@@ -154,7 +158,8 @@ import '../../style/team.css';
                             </span>
                             GitHub
                         </a>
-                        <a href="../../../public/CV/CV_SANTI.pdf" target="_blank">
+                        <!-- CV link: Files in public/ are served from root, so /CV/filename.pdf is the correct path -->
+                        <a href="/CV/CV_SANTI.pdf" target="_blank">
                             <span class="icon">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 24 24"><path d="M6 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8.828A2 2 0 0 0 19.414 7.414l-4.828-4.828A2 2 0 0 0 13.172 2H6zm6 1.414L18.586 10H14a2 2 0 0 1-2-2V3.414z"/></svg>
                             </span>


### PR DESCRIPTION
## 🐛 Problem
CV download links in the team page were broken due to incorrect relative paths pointing to `../../public/CV/` and `../../../public/CV/`.

## ✅ Solution
- Changed all CV links to use absolute paths (`/CV/filename.pdf`)
- In Astro, files in `public/` directory are served from the site root
- Added inline comments explaining the correct path usage

## 📋 Changes
- Fixed CV links for all 5 team members:
  - Julieta Sotelo: `/CV/CV_SOTELO.pdf`
  - Ana Paula Toledo: `/CV/CV_PAULI.pdf`
  - Joaquin Dominguez: `/CV/CV_JOACO.pdf`
  - Sofia Natali Rubio: `/CV/CV_SOFI.pdf`
  - Santiago Suarez: `/CV/CV_SANTI.pdf`

## 🧪 Testing
- [x] Server starts without errors (`npm run dev`)
- [x] No syntax errors in modified file
- [x] CV links now work correctly in browser

## 📁 Files Modified
- `src/pages/team/index.astro`